### PR TITLE
Fixes kmod compiling on newer kernel versions

### DIFF
--- a/core/kmod/sn_netdev.c
+++ b/core/kmod/sn_netdev.c
@@ -605,7 +605,7 @@ static u16 sn_select_queue(struct net_device *netdev, struct sk_buff *skb)
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv)
-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,18,0)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0)
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
 			   void *accel_priv,
@@ -613,8 +613,7 @@ static u16 sn_select_queue(struct net_device *netdev,
 #else
 static u16 sn_select_queue(struct net_device *netdev,
 			   struct sk_buff *skb,
-			   struct net_device *sb_dev,
-			   select_queue_fallback_t fallback)
+			   struct net_device *sb_dev)
 #endif
 {
 	struct sn_device *dev = netdev_priv(netdev);


### PR DESCRIPTION
Works for 4.19 and 5.2. Assuming it will also work for 5/5.1 but have
not tested it.

Signed-off-by: Tim Rozet <trozet@redhat.com>